### PR TITLE
DNM Revert "[nrf fromlist] cmake: Port build scripts to support multi-image"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ zephyr_interface_library_named(TINYCBOR)
 # This line is for compatibility and should be removed at some point of
 # time. It is supposed to allow building sources that still reference cbor
 # headers without tinycbor subrirectory.
-target_include_directories(${IMAGE}TINYCBOR INTERFACE include/tinycbor)
-target_include_directories(${IMAGE}TINYCBOR INTERFACE include)
+target_include_directories(TINYCBOR INTERFACE include/tinycbor)
+target_include_directories(TINYCBOR INTERFACE include)
 
 zephyr_library()
 zephyr_library_sources(
@@ -19,6 +19,6 @@ zephyr_library_sources_ifdef(CONFIG_NEWLIB_LIBC src/cborparser_dup_string.c)
 
 zephyr_library_sources_ifdef(CONFIG_CBOR_PRETTY_PRINTING src/cborpretty.c)
 
-zephyr_library_link_libraries(${IMAGE}TINYCBOR)
-target_link_libraries(${IMAGE}TINYCBOR INTERFACE ${IMAGE}zephyr_interface)
+zephyr_library_link_libraries(TINYCBOR)
+target_link_libraries(TINYCBOR INTERFACE zephyr_interface)
 endif()


### PR DESCRIPTION
This PR introduces the use of the new principle for creating multi image build.

It reverts the only nordic specific commit, so instead of merging this PR, I suggests that we start following upstream SHA in our manifest.

-------
This reverts commit 86d5ed5dd544b107d2d0882961a19c2c6cb06572.

Commit is reverted as part of new multi image approach where ${IMAGE}
is no longer needed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>